### PR TITLE
Fix create form action execution context

### DIFF
--- a/client/src/actions/form.action.ts
+++ b/client/src/actions/form.action.ts
@@ -1,3 +1,5 @@
+"use server";
+
 import fs from "fs/promises";
 import path from "path";
 import { FormType, FormSettings, FormResponse, FormStats } from "@/@types/form.type";


### PR DESCRIPTION
## Summary
- mark server actions with `'use server'` so they stay on the server

## Testing
- `npm install` *(fails: postinstall prompts and environment limitations)*
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68508b3602c8833192d6180591ae4eb9